### PR TITLE
Abstract services regenerated because of pagination problem

### DIFF
--- a/config/model-binding.php
+++ b/config/model-binding.php
@@ -161,5 +161,21 @@ return [
         return NextDeveloper\Communication\Database\Models\CommunicationEmail::findByRef($value);
 },
 
+'communicationnotification' => function ($value) {
+        return NextDeveloper\Communication\Database\Models\CommunicationNotification::findByRef($value);
+},
+
+'communicationuserpreference' => function ($value) {
+        return NextDeveloper\Communication\Database\Models\CommunicationUserPreference::findByRef($value);
+},
+
+'communicationremindable' => function ($value) {
+        return NextDeveloper\Communication\Database\Models\CommunicationRemindable::findByRef($value);
+},
+
+'communicationemail' => function ($value) {
+        return NextDeveloper\Communication\Database\Models\CommunicationEmail::findByRef($value);
+},
+
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 ];

--- a/src/Database/Filters/EmailsQueryFilter.php
+++ b/src/Database/Filters/EmailsQueryFilter.php
@@ -12,6 +12,7 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class EmailsQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
@@ -36,53 +37,53 @@ class EmailsQueryFilter extends AbstractQueryFilter
     {
         return $this->builder->where('is_marketing_email', true);
     }
-    
-    public function deliverAtStart($date) 
+
+    public function deliverAtStart($date)
     {
         return $this->builder->where('deliver_at', '>=', $date);
     }
 
-    public function deliverAtEnd($date) 
+    public function deliverAtEnd($date)
     {
         return $this->builder->where('deliver_at', '<=', $date);
     }
 
-    public function deliveredAtStart($date) 
+    public function deliveredAtStart($date)
     {
         return $this->builder->where('delivered_at', '>=', $date);
     }
 
-    public function deliveredAtEnd($date) 
+    public function deliveredAtEnd($date)
     {
         return $this->builder->where('delivered_at', '<=', $date);
     }
 
-    public function createdAtStart($date) 
+    public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
     }
 
-    public function createdAtEnd($date) 
+    public function createdAtEnd($date)
     {
         return $this->builder->where('created_at', '<=', $date);
     }
 
-    public function updatedAtStart($date) 
+    public function updatedAtStart($date)
     {
         return $this->builder->where('updated_at', '>=', $date);
     }
 
-    public function updatedAtEnd($date) 
+    public function updatedAtEnd($date)
     {
         return $this->builder->where('updated_at', '<=', $date);
     }
 
-    public function deletedAtStart($date) 
+    public function deletedAtStart($date)
     {
         return $this->builder->where('deleted_at', '>=', $date);
     }
 
-    public function deletedAtEnd($date) 
+    public function deletedAtEnd($date)
     {
         return $this->builder->where('deleted_at', '<=', $date);
     }

--- a/src/Database/Filters/NotificationsQueryFilter.php
+++ b/src/Database/Filters/NotificationsQueryFilter.php
@@ -4,7 +4,7 @@ namespace NextDeveloper\Communication\Database\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
-
+        
 
 /**
  * This class automatically puts where clause on database so that use can filter
@@ -12,16 +12,17 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class NotificationsQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
     protected $builder;
-
-    public function notifiableType($value)
+    
+    public function objectType($value)
     {
-        return $this->builder->where('notifiable_type', 'like', '%' . $value . '%');
+        return $this->builder->where('object_type', 'like', '%' . $value . '%');
     }
-
+    
     public function data($value)
     {
         return $this->builder->where('data', 'like', '%' . $value . '%');
@@ -82,11 +83,6 @@ class NotificationsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('deleted_at', '<=', $date);
     }
 
-    public function objectId($value)
-    {
-        return $this->builder->where('object_id', '=', $value);
-    }
-
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -106,4 +102,5 @@ class NotificationsQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Filters/RemindablesQueryFilter.php
+++ b/src/Database/Filters/RemindablesQueryFilter.php
@@ -4,7 +4,7 @@ namespace NextDeveloper\Communication\Database\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
-
+    
 
 /**
  * This class automatically puts where clause on database so that use can filter
@@ -12,16 +12,17 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class RemindablesQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
     protected $builder;
-
-    public function remindableObjectType($value)
+    
+    public function objectType($value)
     {
-        return $this->builder->where('remindable_object_type', 'like', '%' . $value . '%');
+        return $this->builder->where('object_type', 'like', '%' . $value . '%');
     }
-
+    
     public function note($value)
     {
         return $this->builder->where('note', 'like', '%' . $value . '%');
@@ -102,4 +103,5 @@ class RemindablesQueryFilter extends AbstractQueryFilter
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 }

--- a/src/Database/Filters/UserPreferencesQueryFilter.php
+++ b/src/Database/Filters/UserPreferencesQueryFilter.php
@@ -12,6 +12,7 @@ use NextDeveloper\Commons\Database\Filters\AbstractQueryFilter;
  */
 class UserPreferencesQueryFilter extends AbstractQueryFilter
 {
+
     /**
      * @var Builder
      */
@@ -21,43 +22,43 @@ class UserPreferencesQueryFilter extends AbstractQueryFilter
     {
         return $this->builder->where('is_system_email_optout', true);
     }
-    
+
     public function isPhoneOptout()
     {
         return $this->builder->where('is_phone_optout', true);
     }
-    
+
     public function isMarketingEmailOptout()
     {
         return $this->builder->where('is_marketing_email_optout', true);
     }
-    
-    public function createdAtStart($date) 
+
+    public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
     }
 
-    public function createdAtEnd($date) 
+    public function createdAtEnd($date)
     {
         return $this->builder->where('created_at', '<=', $date);
     }
 
-    public function updatedAtStart($date) 
+    public function updatedAtStart($date)
     {
         return $this->builder->where('updated_at', '>=', $date);
     }
 
-    public function updatedAtEnd($date) 
+    public function updatedAtEnd($date)
     {
         return $this->builder->where('updated_at', '<=', $date);
     }
 
-    public function deletedAtStart($date) 
+    public function deletedAtStart($date)
     {
         return $this->builder->where('deleted_at', '>=', $date);
     }
 
-    public function deletedAtEnd($date) 
+    public function deletedAtEnd($date)
     {
         return $this->builder->where('deleted_at', '<=', $date);
     }

--- a/src/Database/Models/Emails.php
+++ b/src/Database/Models/Emails.php
@@ -181,4 +181,5 @@ class Emails extends Model
 
 
 
+
 }

--- a/src/Database/Models/Notifications.php
+++ b/src/Database/Models/Notifications.php
@@ -20,8 +20,8 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @property boolean $is_info
  * @property boolean $is_warning
  * @property boolean $is_error
- * @property integer $notifiable_id
- * @property string $notifiable_type
+ * @property integer $object_id
+ * @property string $object_type
  * @property string $data
  * @property \Carbon\Carbon $read_at
  * @property integer $iam_user_id
@@ -50,8 +50,8 @@ class Notifications extends Model
             'is_info',
             'is_warning',
             'is_error',
-            'notifiable_id',
-            'notifiable_type',
+            'object_id',
+            'object_type',
             'data',
             'read_at',
             'iam_user_id',
@@ -82,8 +82,8 @@ class Notifications extends Model
     'is_info' => 'boolean',
     'is_warning' => 'boolean',
     'is_error' => 'boolean',
-    'notifiable_id' => 'integer',
-    'notifiable_type' => 'string',
+    'object_id' => 'integer',
+    'object_type' => 'string',
     'data' => 'string',
     'read_at' => 'datetime',
     'created_at' => 'datetime',
@@ -151,6 +151,7 @@ class Notifications extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Database/Models/Remindables.php
+++ b/src/Database/Models/Remindables.php
@@ -17,8 +17,8 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @package  NextDeveloper\Communication\Database\Models
  * @property integer $id
  * @property string $uuid
- * @property integer $remindable_id
- * @property string $remindable_object_type
+ * @property integer $object_id
+ * @property string $object_type
  * @property \Carbon\Carbon $remind_datetime
  * @property \Carbon\Carbon $snooze_datetime
  * @property integer $iam_user_id
@@ -47,8 +47,8 @@ class Remindables extends Model
     protected $guarded = [];
 
     protected $fillable = [
-            'remindable_id',
-            'remindable_object_type',
+            'object_id',
+            'object_type',
             'remind_datetime',
             'snooze_datetime',
             'iam_user_id',
@@ -79,8 +79,8 @@ class Remindables extends Model
      */
     protected $casts = [
     'id' => 'integer',
-    'remindable_id' => 'integer',
-    'remindable_object_type' => 'string',
+    'object_id' => 'integer',
+    'object_type' => 'string',
     'remind_datetime' => 'datetime',
     'snooze_datetime' => 'datetime',
     'note' => 'string',
@@ -153,6 +153,7 @@ class Remindables extends Model
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Database/Models/UserPreferences.php
+++ b/src/Database/Models/UserPreferences.php
@@ -157,4 +157,5 @@ class UserPreferences extends Model
 
 
 
+
 }

--- a/src/Http/Requests/Notifications/NotificationsCreateRequest.php
+++ b/src/Http/Requests/Notifications/NotificationsCreateRequest.php
@@ -16,8 +16,8 @@ class NotificationsCreateRequest extends AbstractFormRequest
             'is_info' => 'boolean',
         'is_warning' => 'boolean',
         'is_error' => 'boolean',
-        'notifiable_id' => 'required|exists:notifiables,uuid|uuid',
-        'notifiable_type' => 'required|string',
+        'object_id' => 'required',
+        'object_type' => 'required|string',
         'data' => 'required|string',
         'read_at' => 'nullable|date',
         ];

--- a/src/Http/Requests/Notifications/NotificationsUpdateRequest.php
+++ b/src/Http/Requests/Notifications/NotificationsUpdateRequest.php
@@ -16,8 +16,8 @@ class NotificationsUpdateRequest extends AbstractFormRequest
             'is_info' => 'boolean',
         'is_warning' => 'boolean',
         'is_error' => 'boolean',
-        'notifiable_id' => 'nullable|exists:notifiables,uuid|uuid',
-        'notifiable_type' => 'nullable|string',
+        'object_id' => 'nullable',
+        'object_type' => 'nullable|string',
         'data' => 'nullable|string',
         'read_at' => 'nullable|date',
         ];

--- a/src/Http/Requests/Remindables/RemindablesCreateRequest.php
+++ b/src/Http/Requests/Remindables/RemindablesCreateRequest.php
@@ -13,8 +13,8 @@ class RemindablesCreateRequest extends AbstractFormRequest
     public function rules()
     {
         return [
-            'remindable_id' => 'required|exists:remindables,uuid|uuid',
-        'remindable_object_type' => 'required|string',
+            'object_id' => 'required',
+        'object_type' => 'required|string',
         'remind_datetime' => 'nullable|date',
         'snooze_datetime' => 'nullable|date',
         'note' => 'nullable|string',

--- a/src/Http/Requests/Remindables/RemindablesUpdateRequest.php
+++ b/src/Http/Requests/Remindables/RemindablesUpdateRequest.php
@@ -13,8 +13,8 @@ class RemindablesUpdateRequest extends AbstractFormRequest
     public function rules()
     {
         return [
-            'remindable_id' => 'nullable|exists:remindables,uuid|uuid',
-        'remindable_object_type' => 'nullable|string',
+            'object_id' => 'nullable',
+        'object_type' => 'nullable|string',
         'remind_datetime' => 'nullable|date',
         'snooze_datetime' => 'nullable|date',
         'note' => 'nullable|string',

--- a/src/Http/Transformers/AbstractTransformers/AbstractEmailsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractEmailsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Communication\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Communication\Database\Models\Emails;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class EmailsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,15 +33,30 @@ class AbstractEmailsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Emails $model
      *
      * @return array
      */
     public function transform(Emails $model)
     {
-                        $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-        
+                                                $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -47,7 +81,91 @@ class AbstractEmailsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Emails $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Emails $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Emails $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Emails $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Emails $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Emails $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Emails $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Emails $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Emails $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractNotificationsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractNotificationsTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Communication\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Communication\Database\Models\Notifications;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class NotificationsTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,24 +33,38 @@ class AbstractNotificationsTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Notifications $model
      *
      * @return array
      */
     public function transform(Notifications $model)
     {
-                        $notifiableId = \NextDeveloper\\Database\Models\Notifiables::where('id', $model->notifiable_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                    $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-        
+                                                $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                                                            $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
             'is_info'  =>  $model->is_info,
             'is_warning'  =>  $model->is_warning,
             'is_error'  =>  $model->is_error,
-            'notifiable_id'  =>  $notifiableId ? $notifiableId->uuid : null,
-            'notifiable_type'  =>  $model->notifiable_type,
+            'object_id'  =>  $model->object_id,
+            'object_type'  =>  $model->object_type,
             'data'  =>  $model->data,
             'read_at'  =>  $model->read_at,
             'iam_user_id'  =>  $iamUserId ? $iamUserId->uuid : null,
@@ -43,7 +76,91 @@ class AbstractNotificationsTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Notifications $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Notifications $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Notifications $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Notifications $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Notifications $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Notifications $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Notifications $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Notifications $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Notifications $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractRemindablesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractRemindablesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Communication\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Communication\Database\Models\Remindables;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class RemindablesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,20 +33,34 @@ class AbstractRemindablesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param Remindables $model
      *
      * @return array
      */
     public function transform(Remindables $model)
     {
-                        $remindableId = \NextDeveloper\\Database\Models\Remindables::where('id', $model->remindable_id)->first();
-                    $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
-            'remindable_id'  =>  $remindableId ? $remindableId->uuid : null,
-            'remindable_object_type'  =>  $model->remindable_object_type,
+            'object_id'  =>  $model->object_id,
+            'object_type'  =>  $model->object_type,
             'remind_datetime'  =>  $model->remind_datetime,
             'snooze_datetime'  =>  $model->snooze_datetime,
             'iam_user_id'  =>  $iamUserId ? $iamUserId->uuid : null,
@@ -42,7 +75,91 @@ class AbstractRemindablesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(Remindables $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(Remindables $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(Remindables $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(Remindables $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(Remindables $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(Remindables $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(Remindables $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(Remindables $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(Remindables $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractUserPreferencesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractUserPreferencesTransformer.php
@@ -4,6 +4,25 @@ namespace NextDeveloper\Communication\Http\Transformers\AbstractTransformers;
 
 use NextDeveloper\Communication\Database\Models\UserPreferences;
 use NextDeveloper\Commons\Http\Transformers\AbstractTransformer;
+use NextDeveloper\Commons\Database\Models\Addresses;
+use NextDeveloper\Commons\Database\Models\Comments;
+use NextDeveloper\Commons\Database\Models\Meta;
+use NextDeveloper\Commons\Database\Models\PhoneNumbers;
+use NextDeveloper\Commons\Database\Models\SocialMedia;
+use NextDeveloper\Commons\Database\Models\Votes;
+use NextDeveloper\Commons\Database\Models\Media;
+use NextDeveloper\Commons\Http\Transformers\MediaTransformer;
+use NextDeveloper\Commons\Database\Models\AvailableActions;
+use NextDeveloper\Commons\Http\Transformers\AvailableActionsTransformer;
+use NextDeveloper\Commons\Database\Models\States;
+use NextDeveloper\Commons\Http\Transformers\StatesTransformer;
+use NextDeveloper\Commons\Http\Transformers\CommentsTransformer;
+use NextDeveloper\Commons\Http\Transformers\SocialMediaTransformer;
+use NextDeveloper\Commons\Http\Transformers\MetaTransformer;
+use NextDeveloper\Commons\Http\Transformers\VotesTransformer;
+use NextDeveloper\Commons\Http\Transformers\AddressesTransformer;
+use NextDeveloper\Commons\Http\Transformers\PhoneNumbersTransformer;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Class UserPreferencesTransformer. This class is being used to manipulate the data we are serving to the customer
@@ -14,14 +33,29 @@ class AbstractUserPreferencesTransformer extends AbstractTransformer
 {
 
     /**
+     * @var array
+     */
+    protected array $availableIncludes = [
+        'states',
+        'actions',
+        'media',
+        'comments',
+        'votes',
+        'socialMedia',
+        'phoneNumbers',
+        'addresses',
+        'meta'
+    ];
+
+    /**
      * @param UserPreferences $model
      *
      * @return array
      */
     public function transform(UserPreferences $model)
     {
-                        $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-        
+                                                $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
+                        
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,
@@ -36,7 +70,91 @@ class AbstractUserPreferencesTransformer extends AbstractTransformer
         );
     }
 
+    public function includeStates(UserPreferences $model)
+    {
+        $states = States::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($states, new StatesTransformer());
+    }
+
+    public function includeActions(UserPreferences $model)
+    {
+        $input = get_class($model);
+        $input = str_replace('\\Database\\Models', '', $input);
+
+        $actions = AvailableActions::withoutGlobalScope(AuthorizationScope::class)
+            ->where('input', $input)
+            ->get();
+
+        return $this->collection($actions, new AvailableActionsTransformer());
+    }
+
+    public function includeMedia(UserPreferences $model)
+    {
+        $media = Media::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($media, new MediaTransformer());
+    }
+
+    public function includeSocialMedia(UserPreferences $model)
+    {
+        $socialMedia = SocialMedia::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($socialMedia, new SocialMediaTransformer());
+    }
+
+    public function includeComments(UserPreferences $model)
+    {
+        $comments = Comments::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($comments, new CommentsTransformer());
+    }
+
+    public function includeVotes(UserPreferences $model)
+    {
+        $votes = Votes::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($votes, new VotesTransformer());
+    }
+
+    public function includeMeta(UserPreferences $model)
+    {
+        $meta = Meta::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($meta, new MetaTransformer());
+    }
+
+    public function includePhoneNumbers(UserPreferences $model)
+    {
+        $phoneNumbers = PhoneNumbers::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($phoneNumbers, new PhoneNumbersTransformer());
+    }
+
+    public function includeAddresses(UserPreferences $model)
+    {
+        $addresses = Addresses::where('object_type', get_class($model))
+            ->where('object_id', $model->id)
+            ->get();
+
+        return $this->collection($addresses, new AddressesTransformer());
+    }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
 
 
 

--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -5,6 +5,7 @@ Route::prefix('communication')->group(
         Route::prefix('notifications')->group(
             function () {
                 Route::get('/', 'Notifications\NotificationsController@index');
+                Route::get('/actions', 'Notifications\NotificationsController@getActions');
 
                 Route::get('{communication_notifications}/tags ', 'Notifications\NotificationsController@tags');
                 Route::post('{communication_notifications}/tags ', 'Notifications\NotificationsController@saveTags');
@@ -15,6 +16,8 @@ Route::prefix('communication')->group(
                 Route::get('/{communication_notifications}', 'Notifications\NotificationsController@show');
 
                 Route::post('/', 'Notifications\NotificationsController@store');
+                Route::post('/{communication_notifications}/do/{action}', 'Notifications\NotificationsController@doAction');
+
                 Route::patch('/{communication_notifications}', 'Notifications\NotificationsController@update');
                 Route::delete('/{communication_notifications}', 'Notifications\NotificationsController@destroy');
             }
@@ -23,6 +26,7 @@ Route::prefix('communication')->group(
         Route::prefix('user-preferences')->group(
             function () {
                 Route::get('/', 'UserPreferences\UserPreferencesController@index');
+                Route::get('/actions', 'UserPreferences\UserPreferencesController@getActions');
 
                 Route::get('{communication_user_preferences}/tags ', 'UserPreferences\UserPreferencesController@tags');
                 Route::post('{communication_user_preferences}/tags ', 'UserPreferences\UserPreferencesController@saveTags');
@@ -33,6 +37,8 @@ Route::prefix('communication')->group(
                 Route::get('/{communication_user_preferences}', 'UserPreferences\UserPreferencesController@show');
 
                 Route::post('/', 'UserPreferences\UserPreferencesController@store');
+                Route::post('/{communication_user_preferences}/do/{action}', 'UserPreferences\UserPreferencesController@doAction');
+
                 Route::patch('/{communication_user_preferences}', 'UserPreferences\UserPreferencesController@update');
                 Route::delete('/{communication_user_preferences}', 'UserPreferences\UserPreferencesController@destroy');
             }
@@ -41,6 +47,7 @@ Route::prefix('communication')->group(
         Route::prefix('remindables')->group(
             function () {
                 Route::get('/', 'Remindables\RemindablesController@index');
+                Route::get('/actions', 'Remindables\RemindablesController@getActions');
 
                 Route::get('{communication_remindables}/tags ', 'Remindables\RemindablesController@tags');
                 Route::post('{communication_remindables}/tags ', 'Remindables\RemindablesController@saveTags');
@@ -51,6 +58,8 @@ Route::prefix('communication')->group(
                 Route::get('/{communication_remindables}', 'Remindables\RemindablesController@show');
 
                 Route::post('/', 'Remindables\RemindablesController@store');
+                Route::post('/{communication_remindables}/do/{action}', 'Remindables\RemindablesController@doAction');
+
                 Route::patch('/{communication_remindables}', 'Remindables\RemindablesController@update');
                 Route::delete('/{communication_remindables}', 'Remindables\RemindablesController@destroy');
             }
@@ -59,6 +68,7 @@ Route::prefix('communication')->group(
         Route::prefix('emails')->group(
             function () {
                 Route::get('/', 'Emails\EmailsController@index');
+                Route::get('/actions', 'Emails\EmailsController@getActions');
 
                 Route::get('{communication_emails}/tags ', 'Emails\EmailsController@tags');
                 Route::post('{communication_emails}/tags ', 'Emails\EmailsController@saveTags');
@@ -69,6 +79,8 @@ Route::prefix('communication')->group(
                 Route::get('/{communication_emails}', 'Emails\EmailsController@show');
 
                 Route::post('/', 'Emails\EmailsController@store');
+                Route::post('/{communication_emails}/do/{action}', 'Emails\EmailsController@doAction');
+
                 Route::patch('/{communication_emails}', 'Emails\EmailsController@update');
                 Route::delete('/{communication_emails}', 'Emails\EmailsController@destroy');
             }
@@ -180,8 +192,13 @@ Route::prefix('communication')->group(
 
 
 
+
+
+
+
     }
 );
+
 
 
 

--- a/tests/Database/Models/CommunicationNotificationTestTraits.php
+++ b/tests/Database/Models/CommunicationNotificationTestTraits.php
@@ -58,7 +58,7 @@ trait CommunicationNotificationTestTraits
         $response = $this->http->request(
             'POST', '/communication/communicationnotification', [
             'form_params'   =>  [
-                'notifiable_type'  =>  'a',
+                'object_type'  =>  'a',
                 'data'  =>  'a',
                     'read_at'  =>  now(),
                             ],
@@ -343,12 +343,12 @@ trait CommunicationNotificationTestTraits
         $this->assertTrue(true);
     }
 
-    public function test_communicationnotification_event_notifiable_type_filter()
+    public function test_communicationnotification_event_object_type_filter()
     {
         try {
             $request = new Request(
                 [
-                'notifiable_type'  =>  'a'
+                'object_type'  =>  'a'
                 ]
             );
 

--- a/tests/Database/Models/CommunicationRemindableTestTraits.php
+++ b/tests/Database/Models/CommunicationRemindableTestTraits.php
@@ -58,7 +58,7 @@ trait CommunicationRemindableTestTraits
         $response = $this->http->request(
             'POST', '/communication/communicationremindable', [
             'form_params'   =>  [
-                'remindable_object_type'  =>  'a',
+                'object_type'  =>  'a',
                 'note'  =>  'a',
                     'remind_datetime'  =>  now(),
                     'snooze_datetime'  =>  now(),
@@ -344,12 +344,12 @@ trait CommunicationRemindableTestTraits
         $this->assertTrue(true);
     }
 
-    public function test_communicationremindable_event_remindable_object_type_filter()
+    public function test_communicationremindable_event_object_type_filter()
     {
         try {
             $request = new Request(
                 [
-                'remindable_object_type'  =>  'a'
+                'object_type'  =>  'a'
                 ]
             );
 


### PR DESCRIPTION
Abstract services regenerated because of pagination problem. This problem was creating a security issue. The original was of paginating the objects was with the Laravel Eloquent pagination like $model->paginate(). However this method discards all the security controls added by Builder in AuthorizationRoles. That is why we manually implemented the pagination object.