### PR TITLE
Update composer.json for Laravel 12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     "twilio/sdk": "*"
   },
   "require-dev": {
-    "illuminate/support": "5.5.*",
-    "illuminate/database": "5.5.*",
-    "illuminate/validation": "5.5.*",
+    "illuminate/support": ">=8.0",
+    "illuminate/database": ">=8.0",
+    "illuminate/validation": ">=8.0",
     "guzzlehttp/guzzle": "*"
   },
   "autoload": {


### PR DESCRIPTION
## Summary
- Update `illuminate/*` constraints in `require-dev` from `5.5.*` to `>=8.0` for Laravel 12 compatibility
- Remove abandoned `beyondcode/laravel-websockets` dependency (where applicable)