### PR TITLE
Dev

### DIFF
--- a/src/Envelopes/NotificationEnvelope.php
+++ b/src/Envelopes/NotificationEnvelope.php
@@ -45,8 +45,8 @@ class NotificationEnvelope extends Mailable
     {
         return new Envelope(
             from: new Address(
-                address: config('leo.mail.from'),
-                name: config('leo.mail.from_name')
+                address: config('leo.mail.from', config('mail.from.address')),
+                name: config('leo.mail.from_name', config('mail.from.name'))
             ),
             to: [
                 new Address(

--- a/src/Helpers/Communicate.php
+++ b/src/Helpers/Communicate.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Mail;
 use NextDeveloper\Communication\Database\Models\Channels;
 use NextDeveloper\Communication\Services\MessagesService;
 use NextDeveloper\Communication\Services\NotificationsService;
+use NextDeveloper\Communication\Services\UserPreferencesService;
 use NextDeveloper\IAM\Database\Models\AccountUsers;
 use NextDeveloper\IAM\Database\Models\Users;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
@@ -58,6 +59,12 @@ class Communicate
             Log::warning('[Communicate::sendNotification] No account found for user, skipping notification', [
                 'user_id' => $this->user->id,
             ]);
+            return;
+        }
+
+        $preferences = UserPreferencesService::getForUser($this->user->id);
+
+        if ($preferences->is_system_email_optout) {
             return;
         }
 

--- a/src/Helpers/Communicate.php
+++ b/src/Helpers/Communicate.php
@@ -9,7 +9,9 @@ use NextDeveloper\Communication\Database\Models\Channels;
 use NextDeveloper\Communication\Services\MessagesService;
 use NextDeveloper\Communication\Services\NotificationsService;
 use NextDeveloper\Communication\Services\UserPreferencesService;
+use NextDeveloper\IAM\Database\Models\AccountUsers;
 use NextDeveloper\IAM\Database\Models\Users;
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
 
 /**
  * Convenience wrapper for communicating with an IAM user via the V2 communication module.
@@ -49,8 +51,12 @@ class Communicate
      */
     public function sendNotification(string $severity, string $message, mixed $object = null): void
     {
-        if (!$this->user->iam_account_id) {
-            Log::warning('[Communicate::sendNotification] User has no iam_account_id, skipping notification', [
+        $accountUser = AccountUsers::withoutGlobalScope(AuthorizationScope::class)
+            ->where('iam_user_id', $this->user->id)
+            ->first();
+
+        if (!$accountUser) {
+            Log::warning('[Communicate::sendNotification] No account found for user, skipping notification', [
                 'user_id' => $this->user->id,
             ]);
             return;
@@ -70,7 +76,7 @@ class Communicate
             'object_id'      => $object?->id,
             'object_type'    => $object ? get_class($object) : null,
             'iam_user_id'    => $this->user->id,
-            'iam_account_id' => $this->user->iam_account_id,
+            'iam_account_id' => $accountUser->iam_account_id,
         ]);
     }
 

--- a/src/Helpers/Communicate.php
+++ b/src/Helpers/Communicate.php
@@ -49,6 +49,13 @@ class Communicate
      */
     public function sendNotification(string $severity, string $message, mixed $object = null): void
     {
+        if (!$this->user->iam_account_id) {
+            Log::warning('[Communicate::sendNotification] User has no iam_account_id, skipping notification', [
+                'user_id' => $this->user->id,
+            ]);
+            return;
+        }
+
         $preferences = UserPreferencesService::getForUser($this->user->id);
 
         if ($preferences->is_system_email_optout && $severity === 'info') {

--- a/src/Helpers/Communicate.php
+++ b/src/Helpers/Communicate.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Mail;
 use NextDeveloper\Communication\Database\Models\Channels;
 use NextDeveloper\Communication\Services\MessagesService;
 use NextDeveloper\Communication\Services\NotificationsService;
-use NextDeveloper\Communication\Services\UserPreferencesService;
 use NextDeveloper\IAM\Database\Models\AccountUsers;
 use NextDeveloper\IAM\Database\Models\Users;
 use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
@@ -59,12 +58,6 @@ class Communicate
             Log::warning('[Communicate::sendNotification] No account found for user, skipping notification', [
                 'user_id' => $this->user->id,
             ]);
-            return;
-        }
-
-        $preferences = UserPreferencesService::getForUser($this->user->id);
-
-        if ($preferences->is_system_email_optout && $severity === 'info') {
             return;
         }
 


### PR DESCRIPTION
[Guard against null iam_account_id in sendNotification](https://github.com/nextdeveloper-nl/communication/commit/0cd10bd7a0e1ee2a56737bc282e86527be25eb9e)
[Fall back to mail.from config when leo.mail.from is not set](https://github.com/nextdeveloper-nl/communication/commit/8067e88da467c515f719bdf086ce8991a141eb8e)
[Fix sendNotification always skipping due to missing iam_account_id on…](https://github.com/nextdeveloper-nl/communication/commit/d126fb9abad3d6017378c8050fdf1d305152d538)
[Remove email opt-out guard from sendNotification](https://github.com/nextdeveloper-nl/communication/commit/f359e9fef98411dc4e7890c73955265ee8780dd7)
[Restore user preference opt-out check without severity restriction](https://github.com/nextdeveloper-nl/communication/commit/5e721d25f72d0fd9a63597fe5661ccf67623ee15)