### PR TITLE
fix: Capture severity, message, object in sendNotification closure

### DIFF
--- a/src/Helpers/Communicate.php
+++ b/src/Helpers/Communicate.php
@@ -52,7 +52,7 @@ class Communicate
      */
     public function sendNotification(string $severity, string $message, mixed $object = null): void
     {
-        UserHelper::runAsAdmin(function () {
+        UserHelper::runAsAdmin(function () use ($severity, $message, $object) {
             $accountUser = AccountUsers::withoutGlobalScope(AuthorizationScope::class)
                 ->where('iam_user_id', $this->user->id)
                 ->first();


### PR DESCRIPTION
Variables from the outer scope were not available inside runAsAdmin's closure, causing an undefined variable error at runtime.

[fix: Capture severity, message, object in sendNotification closure](https://github.com/nextdeveloper-nl/communication/commit/a55a36b5383ed8b4a3874a7b96c8c0c4facd33fd)