### PR TITLE
fix: Treat null deliver_at as deliver-immediately in getDueForDelivery

### DIFF
--- a/src/Services/MessagesService.php
+++ b/src/Services/MessagesService.php
@@ -135,12 +135,17 @@ class MessagesService extends AbstractMessagesService
     }
 
     /**
-     * Returns all queued messages whose scheduled delivery time has passed.
+     * Returns all queued messages that are due for delivery.
+     * A null deliver_at means deliver immediately; a set value is delivered
+     * once that timestamp has passed.
      */
     public static function getDueForDelivery(): Collection
     {
         return Messages::where('status', 'queued')
-            ->where('deliver_at', '<=', now())
+            ->where(function ($query) {
+                $query->whereNull('deliver_at')
+                      ->orWhere('deliver_at', '<=', now());
+            })
             ->get();
     }
 


### PR DESCRIPTION
[fix: Treat null deliver_at as deliver-immediately in getDueForDelivery](https://github.com/nextdeveloper-nl/communication/commit/0dca534b92bb5487483e5a65c4c97cf50bf4f1f0)