### PR TITLE
fix: Ensure subject is always passed correctly during email delivery

### DIFF
--- a/src/Http/Requests/Messages/MessagesCreateRequest.php
+++ b/src/Http/Requests/Messages/MessagesCreateRequest.php
@@ -31,6 +31,7 @@ class MessagesCreateRequest extends AbstractFormRequest
         'failure_reason' => 'nullable|string',
         'is_internal' => 'boolean',
         'metadata' => 'nullable',
+        'subject' => 'nullable|string',
         'communication_channel_id' => 'nullable|exists:communication_channels,uuid|uuid',
         'recipient' => 'nullable|string',
         ];

--- a/src/Services/MessagesService.php
+++ b/src/Services/MessagesService.php
@@ -62,6 +62,12 @@ class MessagesService extends AbstractMessagesService
                 ->id;
         }
 
+        // If subject is provided as a top-level field, store it in metadata.
+        if (!empty($data['subject'])) {
+            $data['metadata'] = array_merge($data['metadata'] ?? [], ['subject' => $data['subject']]);
+            unset($data['subject']);
+        }
+
         $message = parent::create($data);
 
         if ($message->communication_thread_id) {
@@ -219,10 +225,10 @@ class MessagesService extends AbstractMessagesService
 
             $processor = new $class(channel: $channel);
             $processor->send([
-                'subject' => $message->metadata['subject'] ?? '(no subject)',
+                'subject' => data_get($message->metadata, 'subject', '(no subject)'),
                 'message' => $message->body,
                 'to'      => $recipient,
-                'cc'      => $message->metadata['cc'] ?? [],
+                'cc'      => data_get($message->metadata, 'cc', []),
             ]);
 
             self::markAsDelivered($message->uuid);


### PR DESCRIPTION
fix: Ensure subject is always passed correctly during email delivery

- MessagesCreateRequest now accepts subject as a top-level field
- MessagesService::create() merges a top-level subject into metadata
- deliver() uses data_get() to safely read metadata.subject and metadata.cc even when metadata is null, preventing the subject from being dropped