### PR TITLE
fix: properly apply CC addresses in SMTP and Gmail channel senders

### DIFF
--- a/src/Channels/Gmail.php
+++ b/src/Channels/Gmail.php
@@ -61,7 +61,7 @@ class Gmail implements ChannelAbstract
             $to      = $message['to'] ?? null;
             $subject = $message['subject'] ?? '(no subject)';
             $body    = $message['message'] ?? $message['body'] ?? '';
-            $cc      = $message['cc'] ?? [];
+            $cc      = array_filter((array) ($message['cc'] ?? []));
 
             $raw = $this->buildRaw($to, $subject, $body, $this->fromAddress, $cc);
 

--- a/src/Channels/Smtp.php
+++ b/src/Channels/Smtp.php
@@ -86,8 +86,9 @@ class Smtp implements ChannelAbstract
                 ->subject($message['subject'] ?? '(no subject)')
                 ->html($message['message'] ?? $message['body'] ?? '');
 
-            foreach ($message['cc'] ?? [] as $cc) {
-                $email->addCc($cc);
+            $ccs = array_filter((array) ($message['cc'] ?? []));
+            if (!empty($ccs)) {
+                $email->cc(...array_map(fn ($addr) => new Address($addr), $ccs));
             }
 
             $this->mailer->send($email);


### PR DESCRIPTION
Smtp: replaced addCc(string) loop with a single ->cc(...Address[]) call using explicit Address objects — addCc with raw strings was silently dropped by Symfony Mailer in some versions.

Gmail: guard the cc array with array_filter to avoid writing an empty
Cc: header into the raw MIME message.