### PR TITLE
fix: resolve channel without AuthorizationScope in background workers

### DIFF
--- a/src/Channels/Gmail.php
+++ b/src/Channels/Gmail.php
@@ -38,6 +38,11 @@ class Gmail implements ChannelAbstract
     {
         $config = $channel->configuration ?? [];
 
+        // Guard against double-encoded JSON (configuration stored as a string in DB)
+        if (is_string($config)) {
+            $config = json_decode($config, true) ?? [];
+        }
+
         if (!$this->validateConfig($config)) {
             throw new InvalidArgumentException(__METHOD__ . ': Missing required Gmail configuration (access_token, refresh_token).');
         }

--- a/src/Channels/Smtp.php
+++ b/src/Channels/Smtp.php
@@ -42,6 +42,10 @@ class Smtp implements ChannelAbstract
     {
         $config = $channel->configuration ?? [];
 
+        if (is_string($config)) {
+            $config = json_decode($config, true) ?? [];
+        }
+
         if (!$this->validateConfig($config)) {
             throw new InvalidArgumentException(__METHOD__ . ': Missing required SMTP configuration fields (host, port, encryption, username, password).');
         }

--- a/src/Services/MessagesService.php
+++ b/src/Services/MessagesService.php
@@ -410,8 +410,10 @@ class MessagesService extends AbstractMessagesService
     private static function resolveChannel(Messages $message): ?Channels
     {
         // 1. Explicit channel preference on the message itself
+        // withoutGlobalScope so background workers (no auth session) can still resolve the channel
         if ($message->communication_channel_id) {
-            $channel = Channels::find($message->communication_channel_id);
+            $channel = Channels::withoutGlobalScope(AuthorizationScope::class)
+                ->find($message->communication_channel_id);
             if ($channel) {
                 return $channel;
             }
@@ -419,9 +421,11 @@ class MessagesService extends AbstractMessagesService
 
         // 2. Channel inherited from the thread
         if ($message->communication_thread_id) {
-            $thread = Threads::find($message->communication_thread_id);
+            $thread = Threads::withoutGlobalScope(AuthorizationScope::class)
+                ->find($message->communication_thread_id);
             if ($thread?->communication_channel_id) {
-                $channel = Channels::find($thread->communication_channel_id);
+                $channel = Channels::withoutGlobalScope(AuthorizationScope::class)
+                    ->find($thread->communication_channel_id);
                 if ($channel) {
                     return $channel;
                 }


### PR DESCRIPTION
## Summary
- Fixed `resolveChannel()` to use `withoutGlobalScope(AuthorizationScope::class)` for all `Channels` and `Threads` lookups — plain `find()` was filtering out records in background queue workers (no auth session), causing fallthrough to the account's primary channel which may have no configuration
- Added JSON string guard in `Gmail` and `Smtp` constructors to handle double-encoded `configuration` values in the DB

## Root cause
In a queue worker, there is no authenticated user session. `AuthorizationScope` silently filtered out the correct channel, the fallback path returned a different channel with no Gmail credentials, and `Gmail::__construct` threw "Missing required Gmail configuration".

## Test plan
- [ ] Send an email via the background `deliver-messages` scheduler and confirm it goes through the correct channel
- [ ] Verify no "Missing required Gmail configuration" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)